### PR TITLE
添加日语翻译（日本語訳を追加）

### DIFF
--- a/src/main/resources/assets/blocktuner/lang/ja_jp.json
+++ b/src/main/resources/assets/blocktuner/lang/ja_jp.json
@@ -1,0 +1,12 @@
+{
+  "blocktuner.enable": "BlockTuner オン",
+  "blocktuner.disable": "BlockTuner オフ",
+  "blocktuner.available": "このサーバーにはBlockTunerがインストールされています",
+
+  "settings.blocktuner.play_mode": "プレイモード",
+  "settings.blocktuner.key_to_piano": "キーボードを音楽キーボードとして入力する",
+  "settings.blocktuner.midi_device": "MIDIデバイス：%s",
+  "settings.blocktuner.refresh": "MIDIデバイスリストを更新する",
+
+  "midi_device.empty": "(無し)"
+}

--- a/源代码/主要的/资源/资产/块调谐器/郎/ja_jp.json
+++ b/源代码/主要的/资源/资产/块调谐器/郎/ja_jp.json
@@ -3,7 +3,7 @@
   "blocktuner.disable": "BlockTuner オフ",
   "blocktuner.available": "このサーバーにはBlockTunerがインストールされています",
 
-  "settings.blocktuner.play_mode": "プレイモード",
+  "settings.blocktuner.play_mode": "演奏モード",
   "settings.blocktuner.key_to_piano": "キーボードを音楽キーボードとして入力する",
   "settings.blocktuner.midi_device": "MIDIデバイス：%s",
   "settings.blocktuner.refresh": "MIDIデバイスリストを更新する",


### PR DESCRIPTION
添加日语翻译
日本語訳を追加

（因为本人日语能力有限，已经尽力让语句读的比较日常化，如果翻译有差错，请提交issue，十分感谢！）
（日本語能力が限られているので、もっと日常的に翻訳できるように頑張りました。翻訳に誤りがありましたら、issueを提出してください、ありがとうございました！）

***

因为原文中"将打字键盘转换为音乐键盘"的音乐键盘不知道要翻译成什么，所以我就先以音乐+键盘的译文翻译了此句，所以可能会有点语句不通顺，还是希望有知道的人能够修改一下，谢谢。
元のテキストで「将打字键盘转换为音乐键盘」の「音乐键盘」を何に翻訳すればよいかわからないので、最初にこの文を音楽+鍵盤の翻訳で翻訳したので、少し混乱するかもしれません。人々はそれを修正することができます、ありがとう。