### PR TITLE
Hardcode nbtKey is not good

### DIFF
--- a/src/main/java/cool/xwj/blocktuner/BlockTunerClient.java
+++ b/src/main/java/cool/xwj/blocktuner/BlockTunerClient.java
@@ -32,6 +32,7 @@ import net.minecraft.util.ActionResult;
 
 @Environment(EnvType.CLIENT)
 public class BlockTunerClient implements ClientModInitializer {
+    public static final String BLOCK_STATE_KEY = "BlockStateTag";
 
     @Override
     public void onInitializeClient() {

--- a/src/main/java/cool/xwj/blocktuner/mixin/NoteBlockMixinClient.java
+++ b/src/main/java/cool/xwj/blocktuner/mixin/NoteBlockMixinClient.java
@@ -17,6 +17,7 @@
 
 package cool.xwj.blocktuner.mixin;
 
+import cool.xwj.blocktuner.BlockTunerClient;
 import cool.xwj.blocktuner.TuningScreen;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
@@ -42,13 +43,13 @@ public class NoteBlockMixinClient extends Block {
     @Override
     public ItemStack getPickStack(BlockView world, BlockPos pos, BlockState state) {
         ItemStack stack = new ItemStack((NoteBlock) (Object) this);
-        int note = state.get(NoteBlock.NOTE);
 
         if (Screen.hasControlDown()) {
+            int note = state.get(NoteBlock.NOTE);
             NbtCompound tag = new NbtCompound();
 
             tag.putInt("note", note);
-            stack.setSubNbt("BlockStateTag", tag);
+            stack.setSubNbt(BlockTunerClient.BLOCK_STATE_KEY, tag);
         }
         return stack;
     }

--- a/src/main/java/cool/xwj/blocktuner/mixin/NoteNameMixin.java
+++ b/src/main/java/cool/xwj/blocktuner/mixin/NoteNameMixin.java
@@ -17,6 +17,7 @@
 
 package cool.xwj.blocktuner.mixin;
 
+import cool.xwj.blocktuner.BlockTunerClient;
 import cool.xwj.blocktuner.NoteNames;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
@@ -31,7 +32,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(ItemStack.class)
 public class NoteNameMixin {
 
-    private static final String BLOCK_STATE_KEY = "BlockStateTag";
+
     private static final String NOTE_KEY = "note";
     private static final Style NOTE_STYLE = Style.EMPTY.withColor(Formatting.AQUA);
 
@@ -39,7 +40,7 @@ public class NoteNameMixin {
     private void getNoteName(CallbackInfoReturnable<Text> cir){
         if (((ItemStack)(Object)this).getItem() == Items.NOTE_BLOCK) {
 
-            NbtCompound nbtCompound = ((ItemStack)(Object)this).getSubNbt(BLOCK_STATE_KEY);
+            NbtCompound nbtCompound = ((ItemStack)(Object)this).getSubNbt(BlockTunerClient.BLOCK_STATE_KEY);
             int note = 0;
 
             if (nbtCompound != null && nbtCompound.contains(NOTE_KEY, 3)) {


### PR DESCRIPTION
Hardcode nbtKey is not good. So I create a public static field `BLOCK_STATE_KEY` for global using. It makes later modification and navigating of the key more convenient. 
About `int note`: It's just a small modification, and you can ignore it.