### PR TITLE
Remove redundant client-catching phase

### DIFF
--- a/src/main/java/cool/xwj/blocktuner/NoteNameHud.java
+++ b/src/main/java/cool/xwj/blocktuner/NoteNameHud.java
@@ -21,7 +21,6 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.NoteBlock;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.util.hit.BlockHitResult;
@@ -30,27 +29,20 @@ import net.minecraft.util.math.BlockPos;
 
 public class NoteNameHud {
 
-    private final MinecraftClient client;
-    private final TextRenderer textRenderer;
-
-    public NoteNameHud(MinecraftClient client) {
-        this.client = client;
-        this.textRenderer = client.textRenderer;
-    }
-
-    public void render(DrawContext context) {
-        assert this.client.world != null;
-        assert this.client.player != null;
-        if(Screen.hasControlDown() && !this.client.player.isSpectator()) {
+    public static void render(DrawContext context) {
+        MinecraftClient client = MinecraftClient.getInstance();
+        assert client.world != null;
+        assert client.player != null;
+        if(Screen.hasControlDown() && !client.player.isSpectator()) {
             HitResult hitResult = client.crosshairTarget;
             if (hitResult != null && hitResult.getType() == HitResult.Type.BLOCK) {
                 BlockPos blockPos = ((BlockHitResult) hitResult).getBlockPos();
-                BlockState state = this.client.world.getBlockState(blockPos);
+                BlockState state = client.world.getBlockState(blockPos);
                 if (state.getBlock() == Blocks.NOTE_BLOCK) {
                     int note = state.get(NoteBlock.NOTE);
-                    int x = this.client.getWindow().getScaledWidth() / 2 + 4;
-                    int y = this.client.getWindow().getScaledHeight() / 2 + 4;
-                    context.drawText(this.textRenderer, NoteNames.get(note) + ", " + note, x, y, 0x55FFFF, true);
+                    int x = client.getWindow().getScaledWidth() / 2 + 4;
+                    int y = client.getWindow().getScaledHeight() / 2 + 4;
+                    context.drawText(client.textRenderer, NoteNames.get(note) + ", " + note, x, y, 0x55FFFF, true);
                 }
             }
         }

--- a/src/main/java/cool/xwj/blocktuner/mixin/InGameHudMixin.java
+++ b/src/main/java/cool/xwj/blocktuner/mixin/InGameHudMixin.java
@@ -31,16 +31,10 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(InGameHud.class)
 public class InGameHudMixin {
 
-    private NoteNameHud noteNameHud;
-
-    @Inject(method = "<init>", at = @At("TAIL"))
-    private void newNoteNameHud(MinecraftClient client, ItemRenderer renderer, CallbackInfo ci) {
-        noteNameHud = new NoteNameHud(client);
-    }
 
     @Inject(method = "render", at = @At("TAIL"))
     private void renderNoteNameHud(DrawContext context, float tickDelta, CallbackInfo ci) {
-        this.noteNameHud.render(context);
+        NoteNameHud.render(context);
         RenderSystem.setShaderColor(1.0f, 1.0f, 1.0f, 1.0f);
     }
 }


### PR DESCRIPTION
### What does the commit do?

1. Remove the client-catching phase in `InGameHudMixin` because `client` instance can be directly read via `MinecraftClient.getInstance();`
2. Remove all the fields in `NoteNameHud` and make `NoteNameHud#render` method static. This makes `NoteNameHud` liter. Now `NoteNameHud` is more like a _helper_ class.

